### PR TITLE
 [FIX] rev cancel image input on form upload product

### DIFF
--- a/apps/templates/modal/upload_product.html
+++ b/apps/templates/modal/upload_product.html
@@ -49,8 +49,6 @@
         const loadingProduct = document.getElementById('loading-product');
         
         imageInputProduct.addEventListener('change', function (event) {
-            loadingProduct.hidden = false;
-            const reader = new FileReader();
             const file = event.target.files[0];
             const maxSize = 8 * 1024 * 1024; // 8MB.
             
@@ -58,7 +56,11 @@
                 if (file.size > maxSize) {
                     alert('Ukuran file tidak boleh lebih dari 8MB.');
                     file.value = '';
+                    imageInputProduct.value = '';
+                    loadingProduct.hidden = true;
                 } else {
+                    loadingProduct.hidden = false;
+                    const reader = new FileReader();
                     reader.onload = function (e) {
                         imagePreviewProduct.src = e.target.result;
                         imagePreviewProduct.hidden = false;

--- a/apps/templates/modal/upload_product.html
+++ b/apps/templates/modal/upload_product.html
@@ -52,16 +52,21 @@
             loadingProduct.hidden = false;
             const reader = new FileReader();
             const file = event.target.files[0];
-            
-            reader.onload = function (e) {
-                imagePreviewProduct.src = e.target.result;
-                imagePreviewProduct.hidden = false;
-            };
+            const maxSize = 8 * 1024 * 1024; // 8MB.
             
             if (file) {
-                reader.readAsDataURL(file);
-                imageInputProduct.hidden = true;
-                loadingProduct.hidden = true;
+                if (file.size > maxSize) {
+                    alert('Ukuran file tidak boleh lebih dari 8MB.');
+                    file.value = '';
+                } else {
+                    reader.onload = function (e) {
+                        imagePreviewProduct.src = e.target.result;
+                        imagePreviewProduct.hidden = false;
+                    };
+                    reader.readAsDataURL(file);
+                    imageInputProduct.hidden = true;
+                    loadingProduct.hidden = true;
+                }
             }
         });
         
@@ -82,7 +87,7 @@
             formData.append('product-description', document.getElementById('product-description').value);
                         
             const inputFile = document.getElementById('product-image-input').files[0];
-            if (inputFile) {
+            if (inputFile) {                
                 formData.append('product-image', inputFile);    
             }
             fetchManager.post(mLink.addProduct, formData)


### PR DESCRIPTION
When img canceledd, loading must be stopped, and field input img must be clear


Here is new code modal/upload_product.html
```python
     imageInputProduct.addEventListener('change', function (event) {
            const file = event.target.files[0];
            const maxSize = 8 * 1024 * 1024; // 8MB.
            
            if (file) {
                if (file.size > maxSize) {
                    alert('Ukuran file tidak boleh lebih dari 8MB.');
                    file.value = '';
                    imageInputProduct.value = '';
                    loadingProduct.hidden = true;
                } else {
                    loadingProduct.hidden = false;
                    const reader = new FileReader();
                    reader.onload = function (e) {
                        imagePreviewProduct.src = e.target.result;
                        imagePreviewProduct.hidden = false;
                    };
                    reader.readAsDataURL(file);
                    imageInputProduct.hidden = true;
                    loadingProduct.hidden = true;
                }
            }
        });
```

